### PR TITLE
Add self-validation on ValidatableSchema

### DIFF
--- a/src/Hubee.Validation.Sdk/Core/Models/ValidatableSchema.cs
+++ b/src/Hubee.Validation.Sdk/Core/Models/ValidatableSchema.cs
@@ -1,10 +1,26 @@
-﻿using Hubee.Validation.Sdk.Core.Interfaces;
+﻿using Hubee.Validation.Sdk.Core.Extensions;
+using Hubee.Validation.Sdk.Core.Interfaces;
 
 namespace Hubee.Validation.Sdk.Core.Models
 {
-    public abstract class ValidatableSchema: IValidatableSchema
+    public abstract class ValidatableSchema : IValidatableSchema
     {
-        public ValidationResult ValidationResult { get; set; }
+        private ValidationResult validationResult;
+
+        public ValidationResult ValidationResult
+        {
+            get
+            {
+                if (validationResult is null)
+                    this.ValidadeSchema();
+
+                return validationResult;
+            }
+            set
+            {
+                validationResult = value;
+            }
+        }
 
         public abstract object GetSchemaRules();
     }

--- a/tests/Hubee.Validation.Sdk.Tests/Core/CommonValidationTests.cs
+++ b/tests/Hubee.Validation.Sdk.Tests/Core/CommonValidationTests.cs
@@ -45,5 +45,14 @@ namespace Hubee.Validation.Sdk.Tests.Core
 
             Assert.Throws<RuleNotSupportedException>(() => { entity.ValidadeSchema(); });
         }
+
+        [Fact]
+        public void TestAutoValidation()
+        {
+            var entity = new EntityCommonTest("", null, null, null);
+
+            Assert.True(entity.ValidationResult.IsInvalid());
+            Assert.Equal(4, entity.ValidationResult.GetErrors().Count);
+        }
     }
 }


### PR DESCRIPTION
An error could be generated when a programmer creates an instance of object without calling
ValidateSchema() method.