### PR TITLE
Fix stringfy na documentação

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ public void JustCheckEntity()
     var cliente = new Cliente().ValidateSchema();
 
     if (cliente.ValidationResult.IsInvalid())
-        throw new Exception(result.Stringify());
+        throw new Exception(cliente.ValidationResult.Stringify());
 }
 ```
 

--- a/src/Hubee.Validation.Sdk/Core/Interfaces/IValidatableSchema.cs
+++ b/src/Hubee.Validation.Sdk/Core/Interfaces/IValidatableSchema.cs
@@ -1,5 +1,5 @@
-﻿using Hubee.Validation.Sdk.Core.Models;
-using Newtonsoft.Json;
+using Hubee.Validation.Sdk.Core.Models;
+using System.Text.Json.Serialization;
 
 namespace Hubee.Validation.Sdk.Core.Interfaces
 {

--- a/src/Hubee.Validation.Sdk/Core/Models/ValidatableSchema.cs
+++ b/src/Hubee.Validation.Sdk/Core/Models/ValidatableSchema.cs
@@ -3,6 +3,7 @@ using Hubee.Validation.Sdk.Core.Helpers;
 using Hubee.Validation.Sdk.Core.Interfaces;
 using Newtonsoft.Json;
 using System.Linq;
+using System.Text.Json.Serialization;
 
 namespace Hubee.Validation.Sdk.Core.Models
 {

--- a/src/Hubee.Validation.Sdk/Hubee.Validation.Sdk.csproj
+++ b/src/Hubee.Validation.Sdk/Hubee.Validation.Sdk.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Hubee.Validation.Sdk</PackageId>
-    <Version>0.0.2.2</Version>
+    <Version>0.0.2.3</Version>
     <Authors>João Antonio Bulgareli</Authors>
     <Company>Hubee</Company>
     <PackageDescription>Framework de validação da Hubee</PackageDescription>
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="System.Text.Json" Version="5.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
@luizmirandati na documentação estávamos apenas chamando `result.Stringify()`, mas agora não temos mais o result. Acessamos o objeto ValidationResult da entidade base.

Dessa forma vai chamar duas vezes o método de hash: uma pra realizar a validação e uma pra gerar a mensagem de erro.

Acha que teremos algum problema de performance por conta disso?